### PR TITLE
Release 1.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,19 @@
 .. :changelog:
 
+
 History
 =======
+
+1.1 (2015-02-02)
+----------------
+
+* Merge ``Signal`` and ``signal`` into one class.
+* Make ``Signal`` an alias of ``signal``.
+* Make ``Signal.define`` an alias of ``signal``.
+* Fix signal support on standalone functions
+  (https://github.com/zyga/morris/issues/1)
+* Add more documentation and tests
+* Enable travis-ci.org integration
 
 1.0 (2014-09-21)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,10 @@ Features
 
 * Free software: LGPLv3 license
 * Documentation: https://morris.readthedocs.org.
-* Create signals with a simple decorator :meth:`morris.Signal.define()` or just
-  :class:`morris.signal`
-* Send signals by calling the decorated method
-* Connect to and disconnect from signals with :meth:`morris.Signal.connect()`
-  and :meth:`morris.Signal.disconnect()`.
+* Create signals with a simple decorator :class:`morris.signal`
+* Send signals by calling the decorated method or function
+* Connect to and disconnect from signals with :meth:`morris.signal.connect()`
+  and :meth:`morris.signal.disconnect()`.
 * Test your code with :meth:`morris.SignalTestCase.watchSignal()`,
   :meth:`morris.SignalTestCase.assertSignalFired()`,
   :meth:`morris.SignalTestCase.assertSignalNotFired()`

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,6 @@ envlist = py27, py32, py33, py34, pypy
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/morris
-commands = python setup.py test
+commands = python setup.py test {posargs}
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This large patch (sorry, I wasn't able to make it into smaller chunks
this time) releases the 1.1 release. The main change is the unification
of Signal (object with listeners) and signal (descriptor) which in turn
makes it possible to have signals that are simple functions (not
classes).

There are a lot of documentation improvements and a lot more tests. In
retrospect, I think this is the first version that really works well.

Fixes: https://github.com/zyga/morris/issues/1
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
